### PR TITLE
Fix link error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Getting started with SvelteJS v3
 
-This is a simple web using [Svelte](https:// .svelte.technology) from [svelte-starter-template](https://github.com/Holben888/svelte-starter-template.git) and [svelte-template](https://github.com/sveltejs/template). To get going, make sure we have [NodeJS](https://nodejs.org/en/) and [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed.
+This is a simple web using [Svelte](https://svelte.dev) from [svelte-starter-template](https://github.com/Holben888/svelte-starter-template.git) and [svelte-template](https://github.com/sveltejs/template). To get going, make sure we have [NodeJS](https://nodejs.org/en/) and [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed.
 
 ...install all project dependencies...
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59497243/142764965-db5539c6-8ab0-410a-8ece-4a88688ff653.png)

(https:// .svelte.technology) changed to (https://svelte.dev)

